### PR TITLE
Update Maven version to one that's published

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To use the checker you need to add the following library to the `pom.xml`:
 <dependency>
   <groupId>com.github.nbaars</groupId>
   <artifactId>pwnedpasswords4j-client</artifactId>
-  <version>1.0.1</version>
+  <version>1.1.0</version>
 </dependency>
 
 ```


### PR DESCRIPTION
No version 1.0.1 available on Maven, updates the docs

http://repo1.maven.org/maven2/com/github/nbaars/pwnedpasswords4j-client/1.1.0/